### PR TITLE
Fix to the bug that caused the menu to not be able to expand in mobile view.

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,12 @@
 	<!-- Optional theme -->
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
 
+	<script
+  		src="https://code.jquery.com/jquery-3.1.1.min.js"
+  		integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8="
+  		crossorigin="anonymous">
+  	</script>
+
 	<!-- Latest compiled and minified JavaScript -->
 	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
@@ -119,7 +125,6 @@
 	<footer class="container-fluid bg-footer text-center">
   		<p>Website Made By Matthew Whitaker | Email: matthew.joe.whitaker@gmail.com | Twitter: <a href="https://twitter.com/MatthewW0610">@MatthewW0610</a></p> 
 	</footer>
-
 
 </body>
 


### PR DESCRIPTION
The bug was that when the user was on a mobile device, bootstrap
automatically changes the 'myNavBar' div to a collapsable menu, however,
when the user clicked the menu button to expand the menu, nothing
happened.

The reason nothing happened was because there wasn't any JavaScript code
for it to work with, so therefore when you clicked the button, it
expected to run some JavaScript code but there wasn't any for it to run.
Therefore by adding the latest JQuery CDN, which Bootstrap requires, it
fixes the problem. Voila!